### PR TITLE
Possible fix for Webpack on Linux failing to compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "html5-simple-date-input-polyfill",
   "version": "1.1.0",
   "description": "input type date polyfill",
@@ -16,5 +16,5 @@
   "analyze": true,
   "license": "MIT",
   "readme": "ERROR: No README data found!"
-} 
- 
+}
+


### PR DESCRIPTION
While trying to port an existing project using this polyfill to a webpack-based workflow I encountered a parsing error:

<code>
Module not found: SyntaxError: /home/.../node_modules/html5-simple-date-input-polyfill/package.json 
(directory description file): SyntaxError:
 /home/.../node_modules/html5-simple-date-input-polyfill/package.json (directory description file): 
SyntaxError: Unexpected token  in JSON at position 0
</code>

I'm working on Linux (Arch) and the reason for this is a uncommon (non-UTF8?) character at the beginning of the package.json file. 

I was able to fix the error by simply re-saving the `package.json` file, but I'm not able to verify the new file is working correctly on Windows or Mac.

I'm creating this pull request and an issue (https://github.com/liorwohl/html5-simple-date-input-polyfill/issues/9) to save other some time figuring this out, even if it can't be merged for any reason.
